### PR TITLE
Add (bio)sample validation [SUBS-528]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Biosamples Validator
-BioSamples validator for the submissions validation service.
+[![Build Status](https://travis-ci.org/EMBL-EBI-SUBS/biosamples-validator.svg?branch=master)](https://travis-ci.org/EMBL-EBI-SUBS/biosamples-validator)
+
+Biosamples validator for the submissions validation service.
+
+This validator evaluates the presence of the following  fields in a [Sample](https://github.com/EMBL-EBI-SUBS/subs-data-model/blob/master/src/main/java/uk/ac/ebi/subs/data/submittable/Sample.java):
+* `Alias`
+* `Release date`
+* `Update date`
+
+When one or more Sample relationships exist each must have:
+* a `Nature` (_child of, derived from, ..._)
+* an `Accession` for the sample target of the relationship 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 sourceCompatibility = 1.8
 
 dependencies {
-    compile ("uk.ac.ebi.subs:validator-common:1.3.0-SNAPSHOT") {
+    compile ("uk.ac.ebi.subs:validator-common:1.4.0-SNAPSHOT") {
         changing = true
         exclude group: 'org.springframework.boot', module :'spring-boot-starter-data-mongodb'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ version '1.0.0-SNAPSHOT'
 buildscript {
     repositories {
         mavenCentral()
-        maven { url 'https://jitpack.io' }
 
     }
     dependencies {
@@ -19,14 +18,13 @@ apply plugin: 'org.springframework.boot'
 
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 sourceCompatibility = 1.8
 
 dependencies {
-    compile ("com.github.EMBL-EBI-SUBS:validator-common:master-SNAPSHOT") {
+    compile ("uk.ac.ebi.subs:validator-common:1.3.0-SNAPSHOT") {
         changing = true
         exclude group: 'org.springframework.boot', module :'spring-boot-starter-data-mongodb'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '1.0.0-SNAPSHOT'
+version '0.1.0-SNAPSHOT'
 
 buildscript {
     repositories {
@@ -30,4 +30,5 @@ dependencies {
     }
 
     compile("org.springframework.boot:spring-boot-starter")
+    testCompile("org.springframework.boot:spring-boot-starter-test")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 sourceCompatibility = 1.8
 
 dependencies {
-    compile ("uk.ac.ebi.subs:validator-common:1.4.0-SNAPSHOT") {
+    compile ("uk.ac.ebi.subs:validator-common:1.5.0-SNAPSHOT") {
         changing = true
         exclude group: 'org.springframework.boot', module :'spring-boot-starter-data-mongodb'
     }

--- a/src/main/java/uk/ac/ebi/subs/validator/biosamples/BiosamplesValidator.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/biosamples/BiosamplesValidator.java
@@ -19,16 +19,16 @@ import java.util.stream.Collectors;
 public class BiosamplesValidator {
     private static Logger logger = LoggerFactory.getLogger(BiosamplesValidator.class);
 
-    private final List<String> relationshipNatureValues = Arrays.asList("derived from", "child of", "same as", "recurated from");
+    private final List<String> relationshipNatureValues = Arrays.asList("derived from", "child of", "same as", "recurated from"); // FIXME - fill list from properties
 
-    private final String NAME_MISSING = "A sample must have an alias.";
+    public final String NAME_MISSING = "A sample must have an alias.";
 
     private final String MULTIPLE_DATES_ERROR = "A sample must only have ONE %s date.";
     private final String MISSING_DATE_VALUE = "A sample must have a %s date.";
 
     private final String SAMPLE_RELATIONSHIP_NULL = "When present, a SampleRelationship must not be null.";
     private final String SAMPLE_RELATIONSHIP_NATURE_MISSING = "A SampleRelationship must have a RelationshipNature.";
-    private final String SAMPLE_RELATIONSHIP_NATURE_UNKNOWN = "SampleRelationship [%s] unknown, please verify if you which to proceed.";
+    private final String SAMPLE_RELATIONSHIP_NATURE_UNKNOWN = "SampleRelationship nature: [%s] unknown, please verify if you wish to proceed.";
     private final String SAMPLE_RELATIONSHIP_TARGET_MISSING = "A SampleRelationship must have a sample accession target.";
 
     public SingleValidationResult validateSample(Sample sample) {
@@ -37,6 +37,10 @@ public class BiosamplesValidator {
         validateName(sample.getAlias(), singleValidationResult);
         validateDates(sample.getAttributes(), singleValidationResult);
         validateSampleRelationships(sample.getSampleRelationships(), singleValidationResult);
+
+        if (singleValidationResult.getValidationStatus().equals(ValidationStatus.Pending)) {
+            singleValidationResult.setValidationStatus(ValidationStatus.Complete);
+        }
 
         return singleValidationResult;
     }
@@ -96,8 +100,10 @@ public class BiosamplesValidator {
     }
 
     private void validateSampleRelationships(List<SampleRelationship> sampleRelationshipList, SingleValidationResult singleValidationResult) {
-        for (SampleRelationship relationship : sampleRelationshipList) {
-            validateSampleRelationship(relationship, singleValidationResult);
+        if(sampleRelationshipList != null && !sampleRelationshipList.isEmpty()) {
+            for (SampleRelationship relationship : sampleRelationshipList) {
+                validateSampleRelationship(relationship, singleValidationResult);
+            }
         }
     }
 

--- a/src/main/java/uk/ac/ebi/subs/validator/biosamples/BiosamplesValidator.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/biosamples/BiosamplesValidator.java
@@ -10,6 +10,7 @@ import uk.ac.ebi.subs.validator.data.SingleValidationResult;
 import uk.ac.ebi.subs.validator.data.ValidationAuthor;
 import uk.ac.ebi.subs.validator.data.ValidationStatus;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -18,39 +19,79 @@ import java.util.stream.Collectors;
 public class BiosamplesValidator {
     private static Logger logger = LoggerFactory.getLogger(BiosamplesValidator.class);
 
-    private static final String SAMPLE_RELATIONSHIP_NULL = "A SampleRelationship must not be null.";
-    private static final String SAMPLE_RELATIONSHIP_NATURE_MISSING = "A SampleRelationship must have a RelationshipNature.";
+    private final List<String> relationshipNatureValues = Arrays.asList("derived from", "child of", "same as", "recurated from");
 
-    private static final String MULTIPLE_RELEASE_DATES_ERROR = "A sample must only have ONE release date.";
-    private static final String MISSING_DATE_VALUE = "A sample must have a %s date.";
+    private final String NAME_MISSING = "A sample must have an alias.";
 
-    // validate release date
+    private final String MULTIPLE_DATES_ERROR = "A sample must only have ONE %s date.";
+    private final String MISSING_DATE_VALUE = "A sample must have a %s date.";
 
-    // validate update date
-
-    // validate sample relationship makes sense to biosamples
+    private final String SAMPLE_RELATIONSHIP_NULL = "When present, a SampleRelationship must not be null.";
+    private final String SAMPLE_RELATIONSHIP_NATURE_MISSING = "A SampleRelationship must have a RelationshipNature.";
+    private final String SAMPLE_RELATIONSHIP_NATURE_UNKNOWN = "SampleRelationship [%s] unknown, please verify if you which to proceed.";
+    private final String SAMPLE_RELATIONSHIP_TARGET_MISSING = "A SampleRelationship must have a sample accession target.";
 
     public SingleValidationResult validateSample(Sample sample) {
         SingleValidationResult singleValidationResult = generateSingleValidationResult(sample);
 
+        validateName(sample.getAlias(), singleValidationResult);
         validateDates(sample.getAttributes(), singleValidationResult);
         validateSampleRelationships(sample.getSampleRelationships(), singleValidationResult);
 
         return singleValidationResult;
     }
 
+    /**
+     * A name in the biosamples sample object is the same as the alias in the USI sample object.
+     * @param alias
+     * @param singleValidationResult
+     */
+    private void validateName(String alias, SingleValidationResult singleValidationResult) {
+        if (alias == null || alias.isEmpty()) {
+            singleValidationResult.setValidationStatus(ValidationStatus.Error);
+            setErrorMessage(singleValidationResult, NAME_MISSING);
+        }
+    }
+
+    /**
+     * Update and release dates must always be present and never more than once.
+     * @param attributes
+     * @param singleValidationResult
+     */
     private void validateDates(List<Attribute> attributes, SingleValidationResult singleValidationResult) {
-        List<Attribute> attributeDates = attributes.stream()
+        // Release date validation
+        List<Attribute> releaseDates = attributes.stream()
                 .filter(
                 attribute -> attribute.getName().equals("release"))
                 .collect(Collectors.toList());
 
-        if (attributeDates.size() > 1) {
-            setErrorMessage(singleValidationResult, MULTIPLE_RELEASE_DATES_ERROR);
-        } else {
-            if (attributeDates.get(0).getValue() == null || attributeDates.get(0).getValue().isEmpty()) {
-                setErrorMessage(singleValidationResult, String.format(MISSING_DATE_VALUE, "release"));
+        validateDates(releaseDates, singleValidationResult, "release");
+
+        // Update date validation
+        List<Attribute> updateDates = attributes.stream()
+                .filter(
+                        attribute -> attribute.getName().equals("update"))
+                .collect(Collectors.toList());
+
+        validateDates(updateDates, singleValidationResult, "update");
+    }
+
+    /**
+     * Generic date presence validation.
+     * @param dates
+     * @param singleValidationResult
+     * @param date
+     */
+    private void validateDates(List<Attribute> dates, SingleValidationResult singleValidationResult, String date) {
+        if (dates.size() > 1) {
+            setErrorMessage(singleValidationResult, String.format(MULTIPLE_DATES_ERROR, date));
+        } else if (dates.get(0) != null) {
+            if (dates.get(0).getValue() == null || dates.get(0).getValue().isEmpty()) {
+                singleValidationResult.setValidationStatus(ValidationStatus.Error);
+                setErrorMessage(singleValidationResult, String.format(MISSING_DATE_VALUE, date));
             }
+        } else {
+            setErrorMessage(singleValidationResult, String.format(MISSING_DATE_VALUE, date));
         }
     }
 
@@ -60,11 +101,31 @@ public class BiosamplesValidator {
         }
     }
 
+    /**
+     * If present, sample relationships must have a nature and target.
+     * @param sampleRelationship
+     * @param singleValidationResult
+     */
     private void validateSampleRelationship(SampleRelationship sampleRelationship, SingleValidationResult singleValidationResult) {
-        if(sampleRelationship.getRelationshipNature() != null) {
+        if (sampleRelationship != null) {
+
+            // Check for nature
             if (sampleRelationship.getRelationshipNature() == null || sampleRelationship.getRelationshipNature().isEmpty()) {
                 singleValidationResult.setValidationStatus(ValidationStatus.Error);
                 setErrorMessage(singleValidationResult, SAMPLE_RELATIONSHIP_NATURE_MISSING);
+            } else {
+                if (!relationshipNatureValues.contains(sampleRelationship.getRelationshipNature())) {
+                    if (singleValidationResult.getValidationStatus().equals(ValidationStatus.Pending)) {
+                        singleValidationResult.setValidationStatus(ValidationStatus.Warning);
+                    }
+                    setErrorMessage(singleValidationResult, String.format(SAMPLE_RELATIONSHIP_NATURE_UNKNOWN, sampleRelationship.getRelationshipNature()));
+                }
+            }
+
+            // Check for target
+            if (sampleRelationship.getAccession() == null || sampleRelationship.getAccession().isEmpty()) {
+                singleValidationResult.setValidationStatus(ValidationStatus.Error);
+                setErrorMessage(singleValidationResult, SAMPLE_RELATIONSHIP_TARGET_MISSING);
             }
         } else {
             singleValidationResult.setValidationStatus(ValidationStatus.Error);
@@ -72,16 +133,23 @@ public class BiosamplesValidator {
         }
     }
 
+    // -- Helper Methods -- //
+
     private SingleValidationResult generateSingleValidationResult(Sample sample) {
         SingleValidationResult result = new SingleValidationResult();
         result.setUuid(UUID.randomUUID().toString());
         result.setEntityUuid(sample.getId());
         result.setValidationAuthor(ValidationAuthor.Biosamples);
-        result.setValidationStatus(ValidationStatus.Pass);
+        result.setValidationStatus(ValidationStatus.Pending);
         return result;
     }
 
     private void setErrorMessage(SingleValidationResult singleValidationResult, String message) {
-        // TODO
+        if (singleValidationResult.getValidationStatus().equals(ValidationStatus.Pending)) {
+            singleValidationResult.setMessage(message);
+        } else {
+            String composedMessage = singleValidationResult.getMessage() + " " + message;
+            singleValidationResult.setMessage(composedMessage);
+        }
     }
 }

--- a/src/main/java/uk/ac/ebi/subs/validator/biosamples/BiosamplesValidator.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/biosamples/BiosamplesValidator.java
@@ -1,0 +1,87 @@
+package uk.ac.ebi.subs.validator.biosamples;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import uk.ac.ebi.subs.data.component.Attribute;
+import uk.ac.ebi.subs.data.component.SampleRelationship;
+import uk.ac.ebi.subs.data.submittable.Sample;
+import uk.ac.ebi.subs.validator.data.SingleValidationResult;
+import uk.ac.ebi.subs.validator.data.ValidationAuthor;
+import uk.ac.ebi.subs.validator.data.ValidationStatus;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class BiosamplesValidator {
+    private static Logger logger = LoggerFactory.getLogger(BiosamplesValidator.class);
+
+    private static final String SAMPLE_RELATIONSHIP_NULL = "A SampleRelationship must not be null.";
+    private static final String SAMPLE_RELATIONSHIP_NATURE_MISSING = "A SampleRelationship must have a RelationshipNature.";
+
+    private static final String MULTIPLE_RELEASE_DATES_ERROR = "A sample must only have ONE release date.";
+    private static final String MISSING_DATE_VALUE = "A sample must have a %s date.";
+
+    // validate release date
+
+    // validate update date
+
+    // validate sample relationship makes sense to biosamples
+
+    public SingleValidationResult validateSample(Sample sample) {
+        SingleValidationResult singleValidationResult = generateSingleValidationResult(sample);
+
+        validateDates(sample.getAttributes(), singleValidationResult);
+        validateSampleRelationships(sample.getSampleRelationships(), singleValidationResult);
+
+        return singleValidationResult;
+    }
+
+    private void validateDates(List<Attribute> attributes, SingleValidationResult singleValidationResult) {
+        List<Attribute> attributeDates = attributes.stream()
+                .filter(
+                attribute -> attribute.getName().equals("release"))
+                .collect(Collectors.toList());
+
+        if (attributeDates.size() > 1) {
+            setErrorMessage(singleValidationResult, MULTIPLE_RELEASE_DATES_ERROR);
+        } else {
+            if (attributeDates.get(0).getValue() == null || attributeDates.get(0).getValue().isEmpty()) {
+                setErrorMessage(singleValidationResult, String.format(MISSING_DATE_VALUE, "release"));
+            }
+        }
+    }
+
+    private void validateSampleRelationships(List<SampleRelationship> sampleRelationshipList, SingleValidationResult singleValidationResult) {
+        for (SampleRelationship relationship : sampleRelationshipList) {
+            validateSampleRelationship(relationship, singleValidationResult);
+        }
+    }
+
+    private void validateSampleRelationship(SampleRelationship sampleRelationship, SingleValidationResult singleValidationResult) {
+        if(sampleRelationship.getRelationshipNature() != null) {
+            if (sampleRelationship.getRelationshipNature() == null || sampleRelationship.getRelationshipNature().isEmpty()) {
+                singleValidationResult.setValidationStatus(ValidationStatus.Error);
+                setErrorMessage(singleValidationResult, SAMPLE_RELATIONSHIP_NATURE_MISSING);
+            }
+        } else {
+            singleValidationResult.setValidationStatus(ValidationStatus.Error);
+            setErrorMessage(singleValidationResult, SAMPLE_RELATIONSHIP_NULL);
+        }
+    }
+
+    private SingleValidationResult generateSingleValidationResult(Sample sample) {
+        SingleValidationResult result = new SingleValidationResult();
+        result.setUuid(UUID.randomUUID().toString());
+        result.setEntityUuid(sample.getId());
+        result.setValidationAuthor(ValidationAuthor.Biosamples);
+        result.setValidationStatus(ValidationStatus.Pass);
+        return result;
+    }
+
+    private void setErrorMessage(SingleValidationResult singleValidationResult, String message) {
+        // TODO
+    }
+}

--- a/src/test/java/uk/ac/ebi/subs/validator/BioSamplesValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/subs/validator/BioSamplesValidatorTest.java
@@ -1,0 +1,76 @@
+package uk.ac.ebi.subs.validator;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ebi.subs.data.submittable.Sample;
+import uk.ac.ebi.subs.validator.biosamples.BiosamplesValidator;
+import uk.ac.ebi.subs.validator.data.SingleValidationResult;
+import uk.ac.ebi.subs.validator.data.ValidationStatus;
+
+import java.util.Arrays;
+
+import static uk.ac.ebi.subs.validator.TestUtils.generateSample;
+import static uk.ac.ebi.subs.validator.TestUtils.generateSampleRelationship;
+
+public class BioSamplesValidatorTest {
+
+    private BiosamplesValidator validator;
+
+    private Sample sample;
+
+    @Before
+    public void setUp() {
+        validator = new BiosamplesValidator();
+        sample = generateSample("sampleAlias");
+    }
+
+    @Test
+    public void sampleAliasMissingTest() {
+        sample.setAlias(null);
+        SingleValidationResult validationResult1 = validator.validateSample(sample);
+        Assert.assertTrue(validationResult1.getMessage().contains(validator.NAME_MISSING));
+
+        sample.setAlias("");
+        SingleValidationResult validationResult2 = validator.validateSample(sample);
+        Assert.assertTrue(validationResult2.getMessage().contains(validator.NAME_MISSING));
+    }
+
+    @Test
+    public void sampleReleaseDateMissingTest() {
+        sample = generateSample("sampleAlias", "");
+        SingleValidationResult validationResult = validator.validateSample(sample);
+        Assert.assertTrue(validationResult.getMessage().contains("A sample must have a release date."));
+    }
+
+    @Test
+    public void sampleRelationshipNatureMissingTest() {
+        sample.setSampleRelationships(Arrays.asList(generateSampleRelationship("SAM12345", "")));
+        SingleValidationResult validationResult = validator.validateSample(sample);
+        Assert.assertTrue(validationResult.getMessage().contains("A SampleRelationship must have a RelationshipNature."));
+    }
+
+    @Test
+    public void sampleRelationshipNatureUnknownTest() {
+        sample.setSampleRelationships(Arrays.asList(generateSampleRelationship("SAM12345", "created from")));
+        SingleValidationResult validationResult = validator.validateSample(sample);
+        Assert.assertTrue(validationResult.getMessage().contains("unknown, please verify if you wish to proceed."));
+    }
+
+    @Test
+    public void sampleRelationshipTargetMissingTest() {
+        sample.setSampleRelationships(Arrays.asList(generateSampleRelationship(null, "derived from")));
+        SingleValidationResult validationResult = validator.validateSample(sample);
+        System.out.println(validationResult);
+        Assert.assertTrue(validationResult.getMessage().contains("A SampleRelationship must have a sample accession target."));
+    }
+
+    @Test
+    public void multipleWarningAndErrorsTest() {
+        sample = generateSample("", "");
+        sample.setSampleRelationships(Arrays.asList(generateSampleRelationship("SAM12345", "created from")));
+        SingleValidationResult validationResult = validator.validateSample(sample);
+        Assert.assertTrue(validationResult.getValidationStatus().equals(ValidationStatus.Error));
+
+    }
+}

--- a/src/test/java/uk/ac/ebi/subs/validator/TestUtils.java
+++ b/src/test/java/uk/ac/ebi/subs/validator/TestUtils.java
@@ -1,0 +1,59 @@
+package uk.ac.ebi.subs.validator;
+
+import uk.ac.ebi.subs.data.component.Attribute;
+import uk.ac.ebi.subs.data.component.SampleRelationship;
+import uk.ac.ebi.subs.data.submittable.Sample;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+public class TestUtils {
+
+    public static Sample generateSample(String alias) {
+        return generateSample(
+                alias,
+                LocalDateTime.now().withDayOfMonth(1).withMonth(4).withYear(2018).format(DateTimeFormatter.ISO_DATE_TIME));
+    }
+
+    public static Sample generateSample(String alias, String release, String update, List<SampleRelationship> relationships) {
+        Sample sample = new Sample();
+        sample.setId(UUID.randomUUID().toString());
+        sample.setAlias(alias);
+        Attribute att = new Attribute();
+        att.setName("release");
+        att.setValue(release);
+        sample.getAttributes().add(att);
+        att = new Attribute();
+        att.setName("update");
+        att.setValue(update);
+        sample.getAttributes().add(att);
+
+        sample.setSampleRelationships(relationships);
+        return sample;
+    }
+
+    public static Sample generateSample(String alias, String release) {
+        Sample sample = new Sample();
+        sample.setId(UUID.randomUUID().toString());
+        sample.setAlias(alias);
+        Attribute att = new Attribute();
+        att.setName("release");
+        att.setValue(release);
+        sample.getAttributes().add(att);
+        att = new Attribute();
+        att.setName("update");
+        att.setValue(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        sample.getAttributes().add(att);
+
+        return sample;
+    }
+
+    public static SampleRelationship generateSampleRelationship(String accession, String nature) {
+        SampleRelationship relationship = new SampleRelationship();
+        relationship.setAccession(accession);
+        relationship.setRelationshipNature(nature);
+        return relationship;
+    }
+}


### PR DESCRIPTION
This validator evaluates the presence of the following  fields in a Sample:
* `Alias`
* `Release date`
* `Update date`

When one or more Sample relationships exist each must have:
* a `Nature` (_child of, derived from, ..._)
  * If an unknown _nature_ is provided a warning is raised.
* an `Accession` for the sample target of the relationship 