### PR TITLE
[SUBS-543] Validator produces results as a SingleValidationResultsEnvelope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '0.2.0-SNAPSHOT'
+version '0.1.0-SNAPSHOT'
 
 buildscript {
     repositories {
@@ -24,8 +24,7 @@ repositories {
 sourceCompatibility = 1.8
 
 dependencies {
-    compile ("uk.ac.ebi.subs:validator-common:1.7.0-SNAPSHOT") {
-        changing = true
+    compile ("uk.ac.ebi.subs:validator-common:1.11.0-SNAPSHOT") {
         exclude group: 'org.springframework.boot', module :'spring-boot-starter-data-mongodb'
     }
 

--- a/src/test/java/uk/ac/ebi/subs/validator/BioSamplesValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/subs/validator/BioSamplesValidatorTest.java
@@ -5,18 +5,21 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.ac.ebi.subs.data.submittable.Sample;
 import uk.ac.ebi.subs.validator.biosamples.BiosamplesValidator;
-import uk.ac.ebi.subs.validator.data.SingleValidationResult;
+import uk.ac.ebi.subs.validator.data.SingleValidationResultsEnvelope;
+import uk.ac.ebi.subs.validator.data.ValidationMessageEnvelope;
 import uk.ac.ebi.subs.validator.data.ValidationStatus;
 
 import java.util.Arrays;
 
 import static uk.ac.ebi.subs.validator.TestUtils.generateSample;
 import static uk.ac.ebi.subs.validator.TestUtils.generateSampleRelationship;
+import static uk.ac.ebi.subs.validator.TestUtils.generateValidationMessageEnvelope;
 
 public class BioSamplesValidatorTest {
 
     private BiosamplesValidator validator;
 
+    private ValidationMessageEnvelope envelope;
     private Sample sample;
 
     @Before
@@ -28,49 +31,54 @@ public class BioSamplesValidatorTest {
     @Test
     public void sampleAliasMissingTest() {
         sample.setAlias(null);
-        SingleValidationResult validationResult1 = validator.validateSample(sample);
-        Assert.assertTrue(validationResult1.getMessage().contains(validator.NAME_MISSING));
+        envelope = generateValidationMessageEnvelope(sample);
+        SingleValidationResultsEnvelope validationResultEnvelope1 = validator.validateSample(envelope);
+        Assert.assertTrue(validationResultEnvelope1.getSingleValidationResults().get(0).getMessage().contains(validator.NAME_MISSING));
 
         sample.setAlias("");
-        SingleValidationResult validationResult2 = validator.validateSample(sample);
-        Assert.assertTrue(validationResult2.getMessage().contains(validator.NAME_MISSING));
+        envelope = generateValidationMessageEnvelope(sample);
+        SingleValidationResultsEnvelope validationResultEnvelope2 = validator.validateSample(envelope);
+        Assert.assertTrue(validationResultEnvelope2.getSingleValidationResults().get(0).getMessage().contains(validator.NAME_MISSING));
     }
 
     @Test
     public void sampleReleaseDateMissingTest() {
         sample = generateSample("sampleAlias", "");
-        SingleValidationResult validationResult = validator.validateSample(sample);
-        Assert.assertTrue(validationResult.getMessage().contains("A sample must have a release date."));
+        envelope = generateValidationMessageEnvelope(sample);
+        SingleValidationResultsEnvelope validationResult = validator.validateSample(envelope);
+        Assert.assertTrue(validationResult.getSingleValidationResults().get(0).getMessage().contains("A sample must have a release date."));
     }
 
     @Test
     public void sampleRelationshipNatureMissingTest() {
         sample.setSampleRelationships(Arrays.asList(generateSampleRelationship("SAM12345", "")));
-        SingleValidationResult validationResult = validator.validateSample(sample);
-        Assert.assertTrue(validationResult.getMessage().contains("A SampleRelationship must have a RelationshipNature."));
+        envelope = generateValidationMessageEnvelope(sample);
+        SingleValidationResultsEnvelope validationResult = validator.validateSample(envelope);
+        Assert.assertTrue(validationResult.getSingleValidationResults().get(0).getMessage().contains("A SampleRelationship must have a RelationshipNature."));
     }
 
     @Test
     public void sampleRelationshipNatureUnknownTest() {
         sample.setSampleRelationships(Arrays.asList(generateSampleRelationship("SAM12345", "created from")));
-        SingleValidationResult validationResult = validator.validateSample(sample);
-        Assert.assertTrue(validationResult.getMessage().contains("unknown, please verify if you wish to proceed."));
+        envelope = generateValidationMessageEnvelope(sample);
+        SingleValidationResultsEnvelope validationResult = validator.validateSample(envelope);
+        Assert.assertTrue(validationResult.getSingleValidationResults().get(0).getMessage().contains("unknown, please verify if you wish to proceed."));
     }
 
     @Test
     public void sampleRelationshipTargetMissingTest() {
         sample.setSampleRelationships(Arrays.asList(generateSampleRelationship(null, "derived from")));
-        SingleValidationResult validationResult = validator.validateSample(sample);
-        System.out.println(validationResult);
-        Assert.assertTrue(validationResult.getMessage().contains("A SampleRelationship must have a sample accession target."));
+        envelope = generateValidationMessageEnvelope(sample);
+        SingleValidationResultsEnvelope validationResult = validator.validateSample(envelope);
+        Assert.assertTrue(validationResult.getSingleValidationResults().get(0).getMessage().contains("A SampleRelationship must have a sample accession target."));
     }
 
     @Test
     public void multipleWarningAndErrorsTest() {
         sample = generateSample("", "");
         sample.setSampleRelationships(Arrays.asList(generateSampleRelationship("SAM12345", "created from")));
-        SingleValidationResult validationResult = validator.validateSample(sample);
-        Assert.assertTrue(validationResult.getValidationStatus().equals(ValidationStatus.Error));
-
+        envelope = generateValidationMessageEnvelope(sample);
+        SingleValidationResultsEnvelope validationResult = validator.validateSample(envelope);
+        Assert.assertTrue(validationResult.getSingleValidationResults().get(0).getValidationStatus().equals(ValidationStatus.Error));
     }
 }

--- a/src/test/java/uk/ac/ebi/subs/validator/TestUtils.java
+++ b/src/test/java/uk/ac/ebi/subs/validator/TestUtils.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.subs.validator;
 import uk.ac.ebi.subs.data.component.Attribute;
 import uk.ac.ebi.subs.data.component.SampleRelationship;
 import uk.ac.ebi.subs.data.submittable.Sample;
+import uk.ac.ebi.subs.validator.data.ValidationMessageEnvelope;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -55,5 +56,13 @@ public class TestUtils {
         relationship.setAccession(accession);
         relationship.setRelationshipNature(nature);
         return relationship;
+    }
+
+    public static ValidationMessageEnvelope generateValidationMessageEnvelope(Sample sample) {
+        return new ValidationMessageEnvelope(
+                UUID.randomUUID().toString(),
+                1,
+                sample
+        );
     }
 }


### PR DESCRIPTION
- Version downgrade
- Update to use `validator-common-1.11.0-SNAPSHOT`
- Validator produces results as a `SingleValidationResultsEnvelope`